### PR TITLE
Correction du type de variable

### DIFF
--- a/core/class/alexafiretv.class.php
+++ b/core/class/alexafiretv.class.php
@@ -293,7 +293,7 @@ class alexafiretv extends eqLogic
 		}
 	$shellExec = $cmd->getConfiguration('request', $_shellExecDefault);
 	$_resultat=$this->lanceCmd($LogicalId,$shellExec);
-	if ($LogicalId == 'DiskTotal') $_resultat=round($_resultat/1000000, 1);
+	if ($LogicalId == 'DiskTotal') $_resultat=round(intval($_resultat)/1000000, 1);
 		
 		
 		//$cmd->setValue($_resultat);


### PR DESCRIPTION
Dans le log Cron Execution on retrouve le PHP Notice suivant :
PHP Notice:  A non well formed numeric value encountered in /var/www/html/plugins/alexafiretv/core/class/alexafiretv.class.php on line 296

Dans ce cas $_resultat est de type string et la division provoque le PHP Notice.
Ajout de la conversion de type pour supprimer le PHP Notice